### PR TITLE
fix filename case

### DIFF
--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -9,7 +9,7 @@ import {ByteArray} from '@/native/builtin/ByteArray'
 import {vm as valueManager, ValueManager} from './value'
 import {AXGlobalClass} from './base'
 import * as ABC from './abc'
-import * as CONSTANT from './constant'
+import * as CONSTANT from './CONSTANT'
 const logger = new Logger('Interpreter')
 type Stack = any[]
 type Locals = any[]

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,4 +1,4 @@
-import * as CONSTANT from './constant'
+import * as CONSTANT from './CONSTANT'
 import * as ABC from './abc'
 import {NamespaceType, TRAIT} from './constant'
 import {Multiname, Namespace} from './abc'


### PR DESCRIPTION
`import * from ‘./constant'`在linux上会报错

然而` import {NamespaceType, TRAIT} from './constant'`不会报错。。。。